### PR TITLE
Use Bootstrap alerts for QSO logging result

### DIFF
--- a/Resources/Views/logQSO.leaf
+++ b/Resources/Views/logQSO.leaf
@@ -17,7 +17,14 @@
   <h1>#(formTitle)</h1>
   <form style="max-width: 350px" action="#(formPath)?#(urlQuery)" method="post">
   #if(error):
-    <p>#(error)</p>
+    <div class="alert alert-danger" role="alert">
+      #(error)
+    </div>
+  #endif
+  #if(successMessage):
+    <div class="alert alert-success" role="alert">
+      #(successMessage)
+    </div>
   #endif
   #if(user.callsign.kind == "unlicensed" && !editing && loggingMode == "training"):
   <p>Using training callsign #(trainingCallsign).</p>

--- a/Sources/App/Controllers/QSOController.swift
+++ b/Sources/App/Controllers/QSOController.swift
@@ -129,6 +129,7 @@ struct QSOController: RouteCollection {
 		var formTitle: String
 		var user: UserModel
 		var error: String?
+		var successMessage: String?
 		var formPath: String
 		var urlQuery: String?
 		var loggingMode: LoggingMode
@@ -323,6 +324,7 @@ struct QSOController: RouteCollection {
 			.get()
 
 		var errorMessage: String? = nil
+		var successMessage: String? = nil
 
 		if reference == nil {
 			errorMessage = "Reference not found."
@@ -446,16 +448,16 @@ struct QSOController: RouteCollection {
 						return req.redirect(to: callback)
 					}
 				case .spot:
-					errorMessage = "Successfully spotted."
+					successMessage = "Successfully spotted."
 				}
-				if errorMessage == nil {
+				if errorMessage == nil && successMessage == nil {
 					let operatorAddition = (contactedOperator?.isEmpty == false) ? " operator \(contactedOperator!)" : ""
-					errorMessage = "Successfully saved your QSO with \(hunterCall)\(operatorAddition)."
+					successMessage = "Successfully saved your QSO with \(hunterCall)\(operatorAddition)."
 				}
 			}
 		}
 
-		return try await req.view.render("logQSO", LogQSOContext(editing:updateMode == .edit, formTitle:title, user:authedUser, error:errorMessage, formPath:req.url.path, urlQuery: req.url.query, loggingMode: loggingMode, trainingCallsign: trainingCallsign, qso:nextForm, knownCallsigns: knownCallsigns(req: req), knownReferences: knownReferences(req: req), common: req.commonContent)).encodeResponse(for: req)
+		return try await req.view.render("logQSO", LogQSOContext(editing:updateMode == .edit, formTitle:title, user:authedUser, error:errorMessage, successMessage: successMessage, formPath:req.url.path, urlQuery: req.url.query, loggingMode: loggingMode, trainingCallsign: trainingCallsign, qso:nextForm, knownCallsigns: knownCallsigns(req: req), knownReferences: knownReferences(req: req), common: req.commonContent)).encodeResponse(for: req)
 	}
 
 	func postDelete(req: Request) async throws -> Response {


### PR DESCRIPTION
Use the red/green Bootstrap alert styles for the message that appears after logging a QSO or spotting yourself.

# Success

![success](https://github.com/user-attachments/assets/1aeb742d-46bc-43e2-8bd1-280f6b40db5d)

# Failure

![failure](https://github.com/user-attachments/assets/c61dba72-cc81-4f5b-87be-3846e5980513)
