### PR TITLE
Add more HTML validations to registration form

### DIFF
--- a/Resources/Views/register-credentials.leaf
+++ b/Resources/Views/register-credentials.leaf
@@ -16,15 +16,15 @@
   </div>
   #endif
   <label class="form-label" for="callsign">Callsign:</label><br>
-  <input class="form-control" type="text" id="callsign" name="callsign" value="#(callsign)" />
+  <input class="form-control" type="text" id="callsign" name="callsign" value="#(callsign)" minlength="3" maxlength="20" required />
   #if(showCallsignCheckOverride):
   <input class="form-check-input" type="checkbox" id="overrideCallsignCountryCheck" name="overrideCallsignCountryCheck"> <label class="form-check-label" for="overrideCallsignCountryCheck">Override callsign country check. I'll only hunt remotely, without operating from within Germany.</label>
   #endif
   <br>
   <label class="form-label" for="password">Password:</label><br>
-  <input class="form-control" type="password" id="password" name="password" autocomplete="new-password" required /><br>
+  <input class="form-control" type="password" id="password" name="password" autocomplete="new-password" minlength="8" maxlength="1024" required /><br>
   <label class="form-label" for="password">Password repeat:</label><br>
-  <input class="form-control" type="password" id="password_repeat" name="password_repeat" autocomplete="new-password" required /><br>
+  <input class="form-control" type="password" id="password_repeat" name="password_repeat" autocomplete="new-password" minlength="8" maxlength="1024" required /><br>
   <fieldset>
     <label>Account type:</label><br>
     <input type="radio" id="licensed" name="accountType" value="licensed" required#if(accountType == "licensed"): checked="checked"#endif />


### PR DESCRIPTION
Add more HTML validations to the password registration form (that match the back-end's behavior) to improve the UX:

1. require a callsign
2. require it be between 3–20 characters
3. require passwords
4. require they be between 8–1024 characters

---
 
![callsign-required](https://github.com/user-attachments/assets/dfacdc1e-684f-49a4-a558-5298cfdd6861)

---

![password-length](https://github.com/user-attachments/assets/3d707c7d-b9a7-415e-890a-25f38272eadb)
